### PR TITLE
Fix badge showing even if user has interacted already

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,9 @@
 ### Added
 - Add link to the hadith web page in the popup screen.
 
+### Fixed
+
+- The unread reminder badge was shown even if the user has already read the today's hadith.
 
 ## [v1.6.0] - 2025-01-28
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -19,8 +19,8 @@ function setDailyUnreadAlarm() {
 function checkInactivity() {
     const currentDate = new Date();
     currentDate.setHours(0, 0, 0, 0)
-    chrome.storage.local.get({lastInteraction: new Date(currentDate.getDate() - 1).toISOString()}, function (result) {
-        const lastInteraction = new Date(result.lastInteraction);
+    chrome.storage.local.get({lastInteractionDate: new Date(currentDate.getDate() - 1).toISOString()}, function (result) {
+        const lastInteraction = new Date(result.lastInteractionDate);
         if (lastInteraction < currentDate) {
             chrome.action.setBadgeText({text: '!'});
             chrome.action.setBadgeBackgroundColor({color: BADGE_COLOR});


### PR DESCRIPTION
- The checkInactivity function is checking wrong stored variable to determine if user has been interacted or not during the day

Fix:
Make sure to check the correct stored variable name

resolves #10